### PR TITLE
Relax upper bound on QuickCheck to allow 2.14

### DIFF
--- a/basic-sop.cabal
+++ b/basic-sop.cabal
@@ -31,7 +31,7 @@ library
   build-depends:       base                 >= 4.6    && < 5,
                        generics-sop         >= 0.2.3  && < 0.6,
                        text                 >= 1.1    && < 1.3,
-                       QuickCheck           >= 2.7    && < 2.14,
+                       QuickCheck           >= 2.7    && < 2.15,
                        deepseq              >= 1.3    && < 1.5
   hs-source-dirs:      src
   default-language:    Haskell2010


### PR DESCRIPTION
The latest version of [QuickCheck](http://hackage.haskell.org/package/QuickCheck) on Hackage is `2.14.2`. I would appreciate the update a lot. Thanks!